### PR TITLE
Added the password policies to self service password configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV LDAP_LTB_BS "dc=ldap,dc=example,dc=com"
 
 # Install Apache2, PHP and LTB ssp
 RUN apt-get update && apt-get install -y apache2 php5 php5-mcrypt php5-ldap curl && apt-get clean
-RUN curl http://tools.ltb-project.org/attachments/download/801/self-service-password_0.9-1_all.deb > self-service-password.deb && dpkg -i self-service-password.deb ; rm -f self-service-password.deb
+RUN curl https://ltb-project.org/archives/self-service-password_0.9-1_all.deb > self-service-password.deb && dpkg -i self-service-password.deb ; rm -f self-service-password.deb
 
 # Configure self-service-password site
 RUN ln -s self-service-password /etc/apache2/sites-available/self-service-password.conf

--- a/README.md
+++ b/README.md
@@ -30,8 +30,18 @@ Runtime configuration can be provided using environment variables:
 * LDAP_LTB_DN, the LDAP admin DN
 * LDAP_LTB_PWD, the password to use connecting to LDAP service
 
+Note : Default password policies is setup with following rules -
+
+* Minimum length: 8
+* Maximum length: 16
+* Minimum number of lowercase characters: 1
+* Minimum number of uppercase characters: 1
+* Minimum number of digits: 1
+* Minimum number of special characters: 1
+* Your new password can not be the same as your old password
+
 # License
-Please view [licence information](LICENCE.md) for the software contained on this image.
+ Please view [licence information](LICENCE.md) for the software contained on this image.
 
 #Supported Docker versions
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Runtime configuration can be provided using environment variables:
 
 Note : Default password policies is setup with following rules -
 
-* Minimum length: 8
-* Maximum length: 16
+* Minimum length: 9
+* Maximum length: no limit
 * Minimum number of lowercase characters: 1
 * Minimum number of uppercase characters: 1
 * Minimum number of digits: 1

--- a/assets/config.inc.php
+++ b/assets/config.inc.php
@@ -64,17 +64,17 @@ $hash = "clear";
 # Local password policy
 # This is applied before directory password policy
 # Minimal length
-$pwd_min_length = 0;
+$pwd_min_length = 8;
 # Maximal length
-$pwd_max_length = 0;
+$pwd_max_length = 16;
 # Minimal lower characters
-$pwd_min_lower = 0;
+$pwd_min_lower = 1;
 # Minimal upper characters
-$pwd_min_upper = 0;
+$pwd_min_upper = 1;
 # Minimal digit characters
-$pwd_min_digit = 0;
+$pwd_min_digit = 1;
 # Minimal special characters
-$pwd_min_special = 0;
+$pwd_min_special = 1;
 # Definition of special characters
 $pwd_special_chars = "^a-zA-Z0-9";
 # Forbidden characters
@@ -87,7 +87,7 @@ $pwd_complexity = 0;
 # always
 # never
 # onerror
-$pwd_show_policy = "never";
+$pwd_show_policy = "onerror";
 # Position of password policy constraints message:
 # above - the form
 # below - the form

--- a/assets/config.inc.php
+++ b/assets/config.inc.php
@@ -64,11 +64,11 @@ $hash = "clear";
 # Local password policy
 # This is applied before directory password policy
 # Minimal length
-$pwd_min_length = 8;
+$pwd_min_length = 9;
 # Maximal length
-$pwd_max_length = 16;
+$pwd_max_length = 0;
 # Minimal lower characters
-$pwd_min_lower = 1;
+$pwd_min_lower = 6;
 # Minimal upper characters
 $pwd_min_upper = 1;
 # Minimal digit characters


### PR DESCRIPTION
This PR updates the configuration for self service password to enforce the password complexity, Documentation is updated to include the password requirements.

Also updated the debian package link as the old one wasn't available anymore. 